### PR TITLE
Fix ISO caching in CI

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -31,19 +31,25 @@ jobs:
           sudo apt-get install -y qemu-system-x86 qemu-utils
           sudo chmod 666 /dev/kvm
 
-      - name: Cache TrueNAS ISO
+      - name: Restore TrueNAS ISO cache
         id: cache-iso
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: /tmp/truenas.iso
           key: truenas-iso-${{ env.TRUENAS_VERSION }}
-          save-always: true
 
       - name: Download TrueNAS ISO
         if: steps.cache-iso.outputs.cache-hit != 'true'
         run: |
           curl -L -o /tmp/truenas.iso \
             "https://download.truenas.com/TrueNAS-SCALE-Goldeye/${TRUENAS_VERSION}/TrueNAS-SCALE-${TRUENAS_VERSION}.iso"
+
+      - name: Save TrueNAS ISO cache
+        if: steps.cache-iso.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: /tmp/truenas.iso
+          key: truenas-iso-${{ env.TRUENAS_VERSION }}
 
       - name: Build setup-truenas
         run: go build -o setup-truenas ./cmd/setup-truenas


### PR DESCRIPTION
## Summary
- Add `save-always: true` to the ISO cache step so the ~1.5GB TrueNAS ISO is saved even when the job fails
- Previously the cache was never saved because `actions/cache@v4` only saves on success by default, and early main branch runs failed

## Test plan
- [ ] Verify the first run downloads and caches the ISO (check "Cache TrueNAS ISO" step output)
- [ ] Verify a second run shows a cache hit