### PR TITLE
ci: detect untracked files in docs verification step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,8 @@ jobs:
       - run: make generate
       - name: Verify docs are up to date
         run: |
-          if [ -n "$(git diff --name-only)" ]; then
+          if [ -n "$(git status --porcelain)" ]; then
             echo "Documentation is out of date. Run 'make generate' and commit the changes."
-            git diff --name-only
+            git status --porcelain
             exit 1
           fi


### PR DESCRIPTION
## Summary

- Use `git status --porcelain` instead of `git diff --name-only` in the docs verification CI step so it also catches new untracked files (e.g. when docs are generated for a newly added resource).

Found while working on #13.

## Test plan

- [ ] Verify CI passes on this PR
- [ ] Confirm that adding a new resource without committing generated docs would fail the check